### PR TITLE
WIP: support use of urls in sites config

### DIFF
--- a/src/network_control.py
+++ b/src/network_control.py
@@ -6,6 +6,7 @@ import logging
 import gc
 import math
 import argparse
+import re
 
 # import matplotlib.pyplot as plt
 from pyrocko import util, model, orthodrome, pile, trace, io
@@ -92,6 +93,14 @@ def get_pl_opt(lats_all, lons_all):
     print(lat_m, lon_m, radius)
 
     return [lat_m, lon_m, radius, 'split']
+
+
+def url_to_filename(site):
+    return re.sub(r'^https?://', '', site).replace('/', '_')
+
+
+def response_file_name(directory, site):
+    return os.path.join(directory, 'Resp_all_%s.xml' % url_to_filename(site))
 
 
 def main(): 
@@ -740,7 +749,7 @@ def main():
                         logs.debug(selection)
 
                         for site in sites:
-                            mseed_fn = mseed_fn_st + site + 'tr.mseed'
+                            mseed_fn = mseed_fn_st + url_to_filename(site) + 'tr.mseed'
 
                             if site in metaDataconf.token:
                                 token = open(metaDataconf.token[site], 'rb').read()
@@ -791,8 +800,6 @@ def main():
                                   metaDataconf.channels_download,
                                   cat_tmin, cat_tmax))
 
-            meta_fn = os.path.join(data_dir, 'Resp_all')
-
             for site in sites:
                 # This sometimes does not work properly, why? Further testing?...
                 logs.info(site)
@@ -802,7 +809,7 @@ def main():
                 except EmptyResult:
                     logs.warning('no metadata for %s from %s' % (selection[1], site))
                     continue
-                request_response.dump_xml(filename='%s_%s.xml' % (meta_fn, site))
+                request_response.dump_xml(filename=response_file_name(data_dir, site))
                 #except:
                 #    print('no metadata at all', site, selection[1])
 
@@ -826,8 +833,8 @@ def main():
             if metaDataconf.use_downmeta is True:
                 logs.debug(' Looking for downloaded metadata.')
                 for site in sites:
-                    stations_fn = os.path.join(data_dir, 'Resp_all_' + str(site) + '.xml')
-                    responses.append(stationxml.load_xml(filename=stations_fn))
+                    responses.append(stationxml.load_xml(
+                        filename=response_file_name(data_dir, site)))
 
             if not metaDataconf.use_downmeta and not metaDataconf.local_metadata:
                 logs.error(' No response files found. Set *use_downmeta* to True '
@@ -1282,9 +1289,7 @@ def main():
             
             if metaDataconf.use_downmeta is True:            
                 for site in sites:
-                    stations_fn = os.path.join(data_dir, 'Resp_all_' + str(site) 
-                                               + '.xml')
-                    st_xml.append(stationxml.load_xml(filename=stations_fn))
+                    st_xml.append(stationxml.load_xml(filename=response_file_name(data_dir, site)))
 
             i_st_xml = len(st_xml)
             for key, subset_catalog in subsets_events.items():


### PR DESCRIPTION
Got a report of someone trying to use e.g. `'http://ceida.ipma.pt'` in the sites configuration. This PR tries to support this case by stripping `'http://'`, `'https://` from the site name when generating response and file names. It also replaces any slashes in the url with underscores. 